### PR TITLE
Migrate to AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ android {
     minSdkVersion 16
     targetSdkVersion 28
 
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   compileOptions {
@@ -70,8 +70,8 @@ dependencies {
   testImplementation 'org.powermock:powermock-api-mockito:1.6.2'
   testImplementation 'org.powermock:powermock-classloading-xstream:1.6.2'
 
-  androidTestImplementation 'com.android.support.test:runner:1.0.2'
-  androidTestImplementation 'com.android.support.test:rules:1.0.2'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+  androidTestImplementation 'androidx.test:rules:1.1.1'
   androidTestImplementation 'junit:junit:4.12'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyAndroidTest.java
+++ b/src/androidTest/java/com/segment/analytics/android/integrations/appboy/AppboyAndroidTest.java
@@ -1,7 +1,6 @@
 package com.segment.analytics.android.integrations.appboy;
 
-import android.support.test.runner.AndroidJUnit4;
-
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.appboy.Appboy;
 import com.appboy.configuration.AppboyConfig;
 import com.segment.analytics.Analytics;
@@ -9,12 +8,11 @@ import com.segment.analytics.Traits;
 import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.test.IdentifyPayloadBuilder;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static android.support.test.InstrumentationRegistry.getContext;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static com.segment.analytics.Utils.createTraits;
 import static org.junit.Assert.assertEquals;
 
@@ -24,7 +22,7 @@ public class AppboyAndroidTest {
   @BeforeClass
   public static void beforeClass() {
     AppboyConfig appboyConfig = new AppboyConfig.Builder().setApiKey("testkey").build();
-    Appboy.configure(getContext(), appboyConfig);
+    Appboy.configure(getApplicationContext(), appboyConfig);
   }
 
   @Test
@@ -33,9 +31,9 @@ public class AppboyAndroidTest {
     Traits traits = createTraits(testUserId);
     IdentifyPayload identifyPayload = new IdentifyPayloadBuilder().traits(traits).build();
     Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
-    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getContext()), "foo", logger, true);
+    AppboyIntegration integration = new AppboyIntegration(Appboy.getInstance(getApplicationContext()), "foo", logger, true);
     integration.identify(identifyPayload);
 
-    assertEquals(testUserId, Appboy.getInstance(getContext()).getCurrentUser().getUserId());
+    assertEquals(testUserId, Appboy.getInstance(getApplicationContext()).getCurrentUser().getUserId());
   }
 }


### PR DESCRIPTION
I replaced deprecated `android.support.test.InstrumentationRegistry.getContext` with `androidx.test.core.app.ApplicationProvider.getApplicationContext`.