### PR TITLE
Changing campaignProps to ValueMap - fixes attribution error

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -221,7 +221,7 @@ public class AppboyIntegration extends Integration<Appboy> {
     Properties properties = track.properties();
     try {
       if (event.equals("Install Attributed")) {
-        Properties campaignProps = (Properties) properties.get("campaign");
+        ValueMap campaignProps = (ValueMap) properties.get("campaign");
         AppboyUser currentUser = mAppboy.getCurrentUser();
         if (campaignProps != null && currentUser != null) {
           currentUser.setAttributionData(new AttributionData(


### PR DESCRIPTION
I've encountered an issue with Install Attribution events. The cast from `properties.get("campaign")` to `Properties` throws an exception.

You can use a `ValueMap` here instead and the exception is not thrown, so the `AttributionData` is set as expecrted.