### PR TITLE
Avoid storing reference to a particular Appboy instance

### DIFF
--- a/appboy-segment-integration/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyInstanceProvider.java
+++ b/appboy-segment-integration/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyInstanceProvider.java
@@ -1,0 +1,8 @@
+package com.segment.analytics.android.integrations.appboy;
+
+import com.appboy.IAppboy;
+
+public interface AppboyInstanceProvider {
+  IAppboy getInstance();
+}
+

--- a/appboy-segment-integration/src/main/java/com/segment/analytics/android/integrations/appboy/DirectAppboyInstanceProvider.java
+++ b/appboy-segment-integration/src/main/java/com/segment/analytics/android/integrations/appboy/DirectAppboyInstanceProvider.java
@@ -1,0 +1,17 @@
+package com.segment.analytics.android.integrations.appboy;
+
+import com.appboy.IAppboy;
+
+public class DirectAppboyInstanceProvider implements AppboyInstanceProvider {
+
+  private IAppboy appboy;
+
+  public DirectAppboyInstanceProvider(IAppboy appboy) {
+    this.appboy = appboy;
+  }
+
+  @Override
+  public IAppboy getInstance() {
+    return appboy;
+  }
+}

--- a/appboy-segment-integration/src/main/java/com/segment/analytics/android/integrations/appboy/FromContextAppboyInstanceProvider.java
+++ b/appboy-segment-integration/src/main/java/com/segment/analytics/android/integrations/appboy/FromContextAppboyInstanceProvider.java
@@ -1,0 +1,18 @@
+package com.segment.analytics.android.integrations.appboy;
+
+import android.content.Context;
+import com.appboy.Appboy;
+
+public class FromContextAppboyInstanceProvider implements AppboyInstanceProvider {
+
+  private final Context mContext;
+
+  public FromContextAppboyInstanceProvider(Context context) {
+    mContext = context;
+  }
+
+  @Override
+  public Appboy getInstance() {
+    return Appboy.getInstance(mContext);
+  }
+}


### PR DESCRIPTION
We have found that we need to do a call to `Braze.wipeData() `using the Android SDK. As the documentation says that call makes the Braze instance unusable.

The problem is that in the Segment connector you are storing the Braze instance in “mAppboy” and there is no way to get a new one after a call to `Braze.wipeData()`.

Accessing the Braze instance through the `Appboy.getInstance()` method works around that issue.