### PR TITLE
fix: Fixed incorrect null check

### DIFF
--- a/appboy-segment-integration/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
+++ b/appboy-segment-integration/src/main/java/com/segment/analytics/android/integrations/appboy/AppboyIntegration.java
@@ -67,7 +67,7 @@ public class AppboyIntegration extends Integration<Braze> {
       boolean inAppMessageRegistrationEnabled =
               settings.getBoolean(AUTOMATIC_IN_APP_MESSAGE_REGISTRATION_ENABLED, true);
 
-      if (StringUtils.isNullOrBlank(API_KEY_KEY)) {
+      if (StringUtils.isNullOrBlank(apiKey)) {
         logger.info("Braze+Segment integration attempted to initialize without api key.");
         return null;
       }


### PR DESCRIPTION
This null check checks if a constant value `API_KEY_KEY` is null, which it never is, while it should be checking for the value this key represents. This api key I believe comes from Segment backend and recent error in their configuration combined with this faulty check, caused 100% crash rate on startup due to NPE
